### PR TITLE
Feature/yaml math evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +279,22 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "meval"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79496a5651c8d57cd033c5add8ca7ee4e3d5f7587a4777484640d9cb60392d9"
+dependencies = [
+ "fnv",
+ "nom",
+]
+
+[[package]]
+name = "nom"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
 
 [[package]]
 name = "obj-drawing"
@@ -371,6 +393,7 @@ dependencies = [
  "approx-eq",
  "colo-rs",
  "lazy_static",
+ "meval",
  "perlin_noise",
  "rayon",
  "serde",

--- a/ray-tracer/Cargo.toml
+++ b/ray-tracer/Cargo.toml
@@ -10,6 +10,7 @@ rayon = "1.10.0"
 perlin_noise = "1.0.1"
 lazy_static = "1.5.0"
 anyhow = "1.0.89"
+meval = "0.2"
 serde_yml = "0.0.12"
 serde = { version = "1.0", features = ["derive"] }
 


### PR DESCRIPTION
Added meval crate to handle math evaluation in yaml field (i.e. you can use math constants such as pi and formulas in some fields)